### PR TITLE
Allow to use different php version defined in artisan file itself.

### DIFF
--- a/artisan.plugin.zsh
+++ b/artisan.plugin.zsh
@@ -15,7 +15,7 @@ function artisan() {
     fi
 
     _artisan_start_time=`date +%s`
-    php $_artisan $*
+    ./$_artisan $*
     _artisan_exit_status=$? # Store the exit status so we can return it later
 
     if [[ $1 = "make:"* && $ARTISAN_OPEN_ON_MAKE_EDITOR != "" ]]; then


### PR DESCRIPTION
Not sure if it's feasible but it may be good option instead of calling 'php' on line 18, let the artisan to pick php version.
This way by changing PHP path in artisan file I can decide myself which php version should be used.